### PR TITLE
Fix border of the .entry:last-child in user page

### DIFF
--- a/kirakiratter.css
+++ b/kirakiratter.css
@@ -876,6 +876,7 @@ button.icon-button.active i.fa-retweet {
 .activity-stream .entry:first-child .status.light,
 .activity-stream .entry:last-child .status.light {
   border-radius: 8px;
+  border: solid 2px #e1c152;
 }
 
 .activity-stream .entry {


### PR DESCRIPTION
There is fix for `border-radius` already, but `border-bottom` is also overwritten. This patch fixes it.

![image](https://cloud.githubusercontent.com/assets/705555/25233296/5e0cd362-2619-11e7-9c21-0e9282b02f29.png)
